### PR TITLE
Included support for 'type' and 'architecture' labels

### DIFF
--- a/centos/6/Dockerfile
+++ b/centos/6/Dockerfile
@@ -1,7 +1,9 @@
 FROM centos:6
 
+LABEL eu.indigo-datacloud.type="linux"
 LABEL eu.indigo-datacloud.distribution="centos"
 LABEL eu.indigo-datacloud.version="6"
+LABEL eu.indigo-datacloud.architecture="amd64"
 
 RUN yum -y update; yum clean all
 RUN yum -y install epel-release; yum clean all

--- a/centos/7/Dockerfile
+++ b/centos/7/Dockerfile
@@ -1,7 +1,9 @@
 FROM centos:7
 
+LABEL eu.indigo-datacloud.type="linux"
 LABEL eu.indigo-datacloud.distribution="centos"
 LABEL eu.indigo-datacloud.version="7"
+LABEL eu.indigo-datacloud.architecture="amd64"
 
 RUN yum -y update; yum clean all
 RUN yum -y install epel-release; yum clean all

--- a/ubuntu/14.04/Dockerfile
+++ b/ubuntu/14.04/Dockerfile
@@ -1,7 +1,9 @@
 FROM ubuntu:14.04
 
+LABEL eu.indigo-datacloud.type="linux"
 LABEL eu.indigo-datacloud.distribution="ubuntu"
 LABEL eu.indigo-datacloud.version="14.04"
+LABEL eu.indigo-datacloud.architecture="amd64"
 
 # Install ansible repository
 RUN apt-get update -y

--- a/ubuntu/16.04/Dockerfile
+++ b/ubuntu/16.04/Dockerfile
@@ -1,7 +1,9 @@
 FROM ubuntu:16.04
 
+LABEL eu.indigo-datacloud.type="linux"
 LABEL eu.indigo-datacloud.distribution="ubuntu"
 LABEL eu.indigo-datacloud.version="16.04"
+LABEL eu.indigo-datacloud.architecture="amd64"
 
 # Install ansible repository
 RUN apt-get update -y


### PR DESCRIPTION
The eu.indigo-datacloud.type and eu.indigo-datacloud.architecture
labels are required for the cloud-info-provider
