### PR TITLE
Included support for INDIGO-DataCloud's package repositories

### DIFF
--- a/centos/7/Dockerfile
+++ b/centos/7/Dockerfile
@@ -6,7 +6,12 @@ LABEL eu.indigo-datacloud.version="7"
 LABEL eu.indigo-datacloud.architecture="amd64"
 
 RUN yum -y update; yum clean all
-RUN yum -y install epel-release; yum clean all
+RUN yum -y install epel-release yum-priorities; yum clean all
+
+#Install INDIGO-DataCloud's package repository (to install a specific version of Ansible)
+RUN echo "check_obsoletes = 1" >> /etc/yum/pluginconf.d/priorities.conf
+RUN wget http://repo.indigo-datacloud.eu/repos/1/indigo1.repo -O /etc/yum.repos.d/indigo1.repo
+RUN rpm --import http://repo.indigo-datacloud.eu/repository/RPM-GPG-KEY-indigodc
 
 #Pre-installed packages to speed IM contextualization
 RUN yum -y install \

--- a/ubuntu/14.04/Dockerfile
+++ b/ubuntu/14.04/Dockerfile
@@ -5,10 +5,10 @@ LABEL eu.indigo-datacloud.distribution="ubuntu"
 LABEL eu.indigo-datacloud.version="14.04"
 LABEL eu.indigo-datacloud.architecture="amd64"
 
-# Install ansible repository
-RUN apt-get update -y
-RUN apt-get install software-properties-common -y
-RUN apt-add-repository ppa:ansible/ansible
+#Install INDIGO-DataCloud's package repository (to install a specific version of Ansible)
+RUN apt-get update && apt-get install -y wget
+RUN wget http://repo.indigo-datacloud.eu/repos/1/indigo1-ubuntu14_04.list -O indigo1-ubuntu14_04.list
+RUN wget -q -O - http://repo.indigo-datacloud.eu/repository/RPM-GPG-KEY-indigodc | sudo apt-key add -
 
 # Pre-install packages to speed IM contextualization
 RUN apt-get update && \


### PR DESCRIPTION
This support is included for CentOS 7 and Ubuntu 14.04 in order to
install a specific version of Ansible. On CentOS 6 and Ubuntu 16.06
(not supported by INDIGO-DataCloud), the latest version of Ansible
available will be installed.
