### PR TITLE
Removed unnecessary dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # os-sshd
 Dockerfiles to create SSH-enabled versions of Docker images for multiple OS
-supported by [INDIGO-DataCloud](http://www.indigo-datacloud.eu),
+supported by [INDIGO-DataCloud](http://www.indigo-datacloud.eu).
 
 Built using official [Ubuntu](https://registry.hub.docker.com/_/ubuntu/) images
 and [CentOS](https://registry.hub.docker.com/_/centos/) images.

--- a/centos/6/Dockerfile
+++ b/centos/6/Dockerfile
@@ -14,8 +14,6 @@ RUN yum -y install \
     openssh-clients \
     openssh-server \
     python-distribute \
-    gcc \
-    python-devel \
     wget \
     openssh-client \
     sshpass \

--- a/centos/6/README.md
+++ b/centos/6/README.md
@@ -13,7 +13,7 @@ Base:
 
 Image specific:
 - [openssh-server](https://help.ubuntu.com/community/SSH/OpenSSH/Configuring)
-- openssh-clients, openssh-server, python-distribute, gcc, python-devel, wget, openssh-client, sshpass, ansible
+- openssh-clients, openssh-server, python-distribute, wget, openssh-client, sshpass, ansible
 
 Config:
 

--- a/centos/7/Dockerfile
+++ b/centos/7/Dockerfile
@@ -6,7 +6,10 @@ LABEL eu.indigo-datacloud.version="7"
 LABEL eu.indigo-datacloud.architecture="amd64"
 
 RUN yum -y update; yum clean all
-RUN yum -y install epel-release yum-priorities; yum clean all
+RUN yum -y install \
+           epel-release \
+           yum-priorities \
+           wget; yum clean all
 
 #Install INDIGO-DataCloud's package repository (to install a specific version of Ansible)
 RUN echo "check_obsoletes = 1" >> /etc/yum/pluginconf.d/priorities.conf
@@ -19,8 +22,6 @@ RUN yum -y install \
     openssh-clients \
     openssh-server \
     python-distribute \
-    gcc \
-    python-devel \
     wget \
     openssh-client \
     sshpass \

--- a/centos/7/README.md
+++ b/centos/7/README.md
@@ -13,7 +13,7 @@ Base:
 
 Image specific:
 - [openssh-server](https://help.ubuntu.com/community/SSH/OpenSSH/Configuring)
-- openssh-clients, openssh-server, python-distribute, gcc, python-devel, wget, openssh-client, sshpass, ansible
+- openssh-clients, openssh-server, python-distribute, wget, openssh-client, sshpass, ansible
 
 Config:
 

--- a/ubuntu/14.04/Dockerfile
+++ b/ubuntu/14.04/Dockerfile
@@ -10,16 +10,13 @@ RUN apt-get update && apt-get install -y wget
 RUN wget http://repo.indigo-datacloud.eu/repos/1/indigo1-ubuntu14_04.list -O indigo1-ubuntu14_04.list
 RUN wget -q -O - http://repo.indigo-datacloud.eu/repository/RPM-GPG-KEY-indigodc | sudo apt-key add -
 
-# Pre-install packages to speed IM contextualization
+# Pre-install packages to speed IM installation
 RUN apt-get update && \
     apt-get install -y \
         ansible \
         cloud-init \
-        gcc \
         openssh-client \
         openssh-server \
-        python-dev \
-        python-pip \
         sshpass \
         unzip \
     && apt-get clean \

--- a/ubuntu/14.04/README.md
+++ b/ubuntu/14.04/README.md
@@ -13,7 +13,7 @@ Base:
 
 Image specific:
 - [openssh-server](https://help.ubuntu.com/community/SSH/OpenSSH/Configuring)
-- python-dev, python-pip, unzip, gcc, openssh-client, sshpass
+- unzip, openssh-client, sshpass
 
 Config:
 

--- a/ubuntu/16.04/Dockerfile
+++ b/ubuntu/16.04/Dockerfile
@@ -6,7 +6,7 @@ LABEL eu.indigo-datacloud.version="16.04"
 LABEL eu.indigo-datacloud.architecture="amd64"
 
 # Install ansible repository
-RUN apt-get update -y
+RUN apt-get update -y && apt-get install -y wget
 RUN apt-get install software-properties-common -y
 RUN apt-add-repository ppa:ansible/ansible
 
@@ -15,11 +15,8 @@ RUN apt-get update && \
     apt-get install -y \
         ansible \
         cloud-init \
-        gcc \
         openssh-client \
         openssh-server \
-        python-dev \
-        python-pip \
         sshpass \
         unzip \
     && apt-get clean \

--- a/ubuntu/16.04/README.md
+++ b/ubuntu/16.04/README.md
@@ -13,7 +13,7 @@ Base:
 
 Image specific:
 - [openssh-server](https://help.ubuntu.com/community/SSH/OpenSSH/Configuring)
-- python-dev, python-pip, unzip, gcc, openssh-client, sshpass
+- unzip, openssh-client, sshpass
 
 Config:
 


### PR DESCRIPTION
Since the IM is now installed from repository, no development packages
(gcc, python-devel) are now required. This will reduce the size of the
base images.
